### PR TITLE
org.clojure/clojure 2.3.4 released

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :url "http://hatnik.clojurecup.com"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "2.3.4"]
                  [org.clojure/clojurescript "0.0-2644"]])


### PR DESCRIPTION
org.clojure/clojure 2.3.4 has been released. Previous version was 1.2.3.

This pull request is created on behalf of @nbeloglazov
